### PR TITLE
Plot patch

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -2,6 +2,7 @@ tree.plot.internal <- function (x, regimes = NULL, labels = x@nodelabels, legend
   rx <- range(x@times,na.rm=T)
   rxd <- 0.1*diff(rx)
   anc <- x@anc.numbers
+  term <- x@term
   root <- which(is.root.node(anc))
   if (is.null(regimes)) {
     regimes <- factor(rep('unspec',length(anc)))
@@ -17,7 +18,7 @@ tree.plot.internal <- function (x, regimes = NULL, labels = x@nodelabels, legend
     levs <- setdiff(levs,regimes[root])
   palette <- rainbow(length(levs))
   for (r in 1:length(levs)) {
-    yy <- arrange.tree(root,anc)
+    yy <- arrange.tree.even(root,anc, term)
     xx <- x@times
     f <- which(!is.root.node(anc) & regimes == levs[r])
     pp <- anc[f]
@@ -38,6 +39,33 @@ tree.plot.internal <- function (x, regimes = NULL, labels = x@nodelabels, legend
   if (legend)
     legend('topleft',levs,lwd=1,col=palette,bty='n')
   invisible(NULL)
+}
+
+arrange.tree.even <- function(root=1, anc, term){    ## calculate even spacing along y
+  k <- which(anc==root)
+  n <- length(k)   # 1 or 2 (or 3, etc)
+  reltree <- rep(0,length(anc))
+  reltree[term] <- 0:(length(term)-1)*(.95-.05)/(length(term)-1)+.05  ## space terminal taxa
+  y <- vector()
+  p <- list()
+  
+  if (root %in% term) {
+    y <- reltree[root]
+    names(y) <- root
+  	return(y)          # return y of tips
+   }  else {
+      for (j in 1:n) {
+    	p[[j]] <- arrange.tree.even(k[j], anc, term)
+    	y <- c(y, p[[j]]) 
+      }
+
+      x <- mean(unlist(p)[as.character(k)])   # x is mean of descendants 
+      names(x) <- root
+      y <- c(y,x)
+      oo <- as.character(sort(as.numeric(names(y))))  # sorted in node order
+      return(y[oo])	
+
+  }
 }
 
 arrange.tree <- function (root, anc) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -68,26 +68,6 @@ arrange.tree.even <- function(root=1, anc, term){    ## calculate even spacing a
   }
 }
 
-arrange.tree <- function (root, anc) {
-  k <- which(anc==root)
-  n <- length(k)
-  reltree <- rep(0,length(anc))
-  reltree[root] <- 0.5
-  p <- list()
-  if (n > 0) {
-    m <- rep(0,n)
-    for (j in 1:n) {
-      p[[j]] <- arrange.tree(k[j],anc)
-      m[j] <- length(which(p[[j]] != 0))
-    }
-    cm <- c(0,cumsum(m))
-    for (j in 1:n) {
-      reltree <- reltree + (cm[j]/sum(m))*(p[[j]] != 0) + (m[j]/sum(m))*p[[j]]
-    }
-  }
-  reltree
-}
-
 setMethod(
           'plot',
           'ouchtree',

--- a/R/plot.R
+++ b/R/plot.R
@@ -41,7 +41,7 @@ tree.plot.internal <- function (x, regimes = NULL, labels = x@nodelabels, legend
   invisible(NULL)
 }
 
-arrange.tree.even <- function(root=1, anc, term){    ## calculate even spacing along y
+arrange.tree.even <- function(root, anc, term){    ## calculate even spacing along y
   k <- which(anc==root)
   n <- length(k)   # 1 or 2 (or 3, etc)
   reltree <- rep(0,length(anc))


### PR DESCRIPTION
Hi Aaron, 
I wrote a patch that I hope you will consider adding to the plot functions. I would like to draw the phylogenies with the taxa evenly spaced (the horizontal lines). The main change was to 
```
arrange.tree(root, anc, term)
```
and a couple of lines in the `tree.plot.internal()`. I couldnʻt figure out how to modify your branch spacing calculation, so I just went with a more traditional post-order traversal and taking the mean of the children to calculate the y-position of the parent node. 

On a large phylogeny, the spacing becomes apparent when there are many branches that are not bifurcating (singleton branches are closer together, bifurcating lineages are spaced more generously). For example in Jeffʻs 2009 paper --
<img width="662" alt="fibertype" src="https://user-images.githubusercontent.com/35955837/108040349-49b73400-6fe1-11eb-94e5-e3b5adc63d42.png">

Compare a tree with the original plot function [originalplot.pdf](https://github.com/kingaa/ouch/files/5987213/originalplot.pdf)
with the patch version
[microhylid.pdf](https://github.com/kingaa/ouch/files/5987216/microhylid.pdf). this is our new Microhylid phylogeny.

Some of the subclades are rotated from your original plot function (still identical in terms of topology) - but I couldnʻt figure out how to get an exact match.  Hope you are well. 

Marguerite
